### PR TITLE
Make suppression tags configurable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.analysis.typeCheckingMode": "basic"
+}

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -28,7 +28,7 @@ def _mypy_impl(target, ctx):
         return []
 
     # disable if a target is tagged with at least one suppression tag
-    for tag in ctx.attr.suppression_tags:
+    for tag in ctx.attr._suppression_tags:
         if tag in ctx.rule.attr.tags:
             return []
 
@@ -169,8 +169,8 @@ def mypy(mypy_cli = None, mypy_ini = None, types = None, cache = True, suppressi
             # this kind of attr to pass naturally
             "_types_keys": attr.label_list(default = types.keys()),
             "_types_values": attr.label_list(default = types.values()),
+            "_suppression_tags": attr.string_list(default = suppression_tags or ["no-mypy"]),
             "cache": attr.bool(default = cache),
-            "suppression_tags": attr.string_list(default = suppression_tags or ["no-mypy"]),
         } | additional_attrs,
     )
 


### PR DESCRIPTION
In our use-case, we want to suppress running mypy using either the tag `no-mypy` or the tag `no-lint`. Before we open-sourced this ruleset, we used an "eligibility function", but almost always configured that using rule kind and tags, so we're opting here for the narrower (and simpler to perform) customization.
