### PR TITLE
Add explicit colorama dep

### DIFF
--- a/mypy/private/requirements.in
+++ b/mypy/private/requirements.in
@@ -1,3 +1,3 @@
 click~=8.1.7
 mypy~=1.11.2
-colorama
+colorama~=0.4.6

--- a/mypy/private/requirements.in
+++ b/mypy/private/requirements.in
@@ -1,2 +1,3 @@
 click~=8.1.7
 mypy~=1.11.2
+colorama

--- a/mypy/private/requirements.txt
+++ b/mypy/private/requirements.txt
@@ -6,6 +6,10 @@ click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
     # via -r mypy/private/requirements.in
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+    # via -r mypy/private/requirements.in
 mypy==1.11.2 \
     --hash=sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36 \
     --hash=sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce \


### PR DESCRIPTION
This dep is an optional dep of click when on windows. If this isn't included always, you hit this issue https://github.com/bazelbuild/rules_python/issues/2223

This is reproducible with `bazel query 'deps(...)'` in this repo before this change.