### PR TITLE
Extend mypy path to find dependencies

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -75,7 +75,7 @@ def _mypy_impl(target, ctx):
 
     # types need to appear first in the mypy path since the module directories
     # are the same and mypy resolves the first ones, first.
-    mypy_path = ":".join(types + external_deps + unique_generated_dirs)
+    mypy_path = ":".join(types + external_deps + unique_generated_dirs + [ctx.label.package])
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 


### PR DESCRIPTION
Status Quo:
* if running `rules_mypy` aspect over a `py_test` which imports from a `deps`, it will fail to find the library
* Example:
```
py_test(
    name = "unit",
    srcs = ["test_checking_classes.py", ":__test__.py"],
    args = ["--config-file=$(location pyproject.toml)"],
    data = ["pyproject.toml", ":cmk-agent-based"],
    main = ":__test__.py",
    deps = [
        ":__test__",
        ":cmk-agent-based", # <--- the test is importing from this py_library
        requirement("pytest"),
    ],
)
```
* a trace may look like:
```
test_checking_classes.py:12: error: Cannot find implementation or library stub for module named "cmk.agent_based.v1"  [import-not-found]
test_checking_classes.py:13: error: Cannot find implementation or library stub for module named "cmk.agent_based.v1._checking_classes"  [import-not-found]
test_checking_classes.py:13: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
test_checking_classes.py:17: error: Expression has type "Any"  [misc]
```
* in result, all `imports` are rendered to `Any` to `mypy` which let's the aspect to fail

Solution:
* extend `mypy_path` to the external deps

