### PR TITLE
Add repro case for missing imports when using 'imports'

### DIFF
--- a/examples/demo/repro/BUILD.bazel
+++ b/examples/demo/repro/BUILD.bazel
@@ -1,0 +1,12 @@
+py_library(
+    name = "a",
+    srcs = glob(["a/**/*.py"]),
+    imports = ["a"],
+)
+
+py_library(
+    name = "b",
+    srcs = glob(["b/**/*.py"]),
+    imports = ["b"],
+    deps = [":a"],
+)

--- a/examples/demo/repro/a/a.py
+++ b/examples/demo/repro/a/a.py
@@ -1,0 +1,2 @@
+def foo(x: int) -> None:
+    pass

--- a/examples/demo/repro/b/b.py
+++ b/examples/demo/repro/b/b.py
@@ -1,0 +1,5 @@
+import a
+
+
+def bar() -> None:
+    a.foo("hello")


### PR DESCRIPTION
When using custom `imports` on a `py_library`, the MYPYPATH is not
updated, so these end up causing missing import errors (or silent false
negatives if you disable missing imports)
