### PR TITLE
Add imports from current target to MYPYPATH

### DIFF
--- a/examples/demo/standalone_imports/BUILD.bazel
+++ b/examples/demo/standalone_imports/BUILD.bazel
@@ -1,0 +1,5 @@
+py_library(
+    name = "foo",
+    srcs = glob(["*.py"]),
+    imports = ["."],
+)

--- a/examples/demo/standalone_imports/a.py
+++ b/examples/demo/standalone_imports/a.py
@@ -1,0 +1,2 @@
+def foo():
+    pass

--- a/examples/demo/standalone_imports/b.py
+++ b/examples/demo/standalone_imports/b.py
@@ -1,0 +1,1 @@
+from a import foo

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -56,6 +56,9 @@ def _mypy_impl(target, ctx):
         if dep.label in type_mapping
     ]
 
+    if PyInfo in target:
+        custom_imports.extend([x.split("/", 1)[-1] for x in target[PyInfo].imports.to_list()])
+
     for dep in (ctx.rule.attr.deps + additional_types):
         depsets.append(dep.default_runfiles.files)
 


### PR DESCRIPTION
The previous handling I added only applied to a target's deps, if you
have a standalone py_library with custom imports, this is necessary for
the same reason
