### PR TITLE
Add support for generated files with custom imports

### DIFF
--- a/examples/demo/generated_file_imports/BUILD.bazel
+++ b/examples/demo/generated_file_imports/BUILD.bazel
@@ -1,0 +1,7 @@
+py_binary(
+    name = "foo",
+    srcs = ["foo.py"],
+    deps = [
+        "//generated_file_imports/nested:bar",
+    ],
+)

--- a/examples/demo/generated_file_imports/foo.py
+++ b/examples/demo/generated_file_imports/foo.py
@@ -1,0 +1,3 @@
+from bar import foo
+
+foo()

--- a/examples/demo/generated_file_imports/nested/BUILD.bazel
+++ b/examples/demo/generated_file_imports/nested/BUILD.bazel
@@ -1,0 +1,12 @@
+genrule(
+    name = "generate_source",
+    outs = ["bar.py"],
+    cmd = "echo 'def foo(): print(\"hi\")' > $(OUTS)",
+)
+
+py_library(
+    name = "bar",
+    srcs = ["bar.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -80,10 +80,14 @@ def _mypy_impl(target, ctx):
         # file roots?
 
     unique_generated_dirs = generated_dirs.keys()
+    generated_custom_imports = []
+    for generated_dir in unique_generated_dirs:
+        for custom_import in custom_imports:
+            generated_custom_imports.append("{}/{}".format(generated_dir, custom_import))
 
     # types need to appear first in the mypy path since the module directories
     # are the same and mypy resolves the first ones, first.
-    mypy_path = ":".join(types + external_deps + custom_imports + unique_generated_dirs)
+    mypy_path = ":".join(types + external_deps + custom_imports + unique_generated_dirs + generated_custom_imports)
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 


### PR DESCRIPTION
If the source files of a py_library are generated, and the library has
custom `imports`, we need to add both the imports path and the generated
dir's relative import path to the MYPYPATH
