### PR TITLE
Deduplicate import dirs in mypy path, minor cleanups

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -94,12 +94,12 @@ def _mypy_impl(target, ctx):
         # and as a way to skip iterating over depset contents to find generated
         # file roots?
 
-    unique_imports_dirs = custom_imports.keys()
+    unique_imports_dirs = imports_dirs.keys()
     unique_generated_dirs = generated_dirs.keys()
     generated_imports_dirs = []
     for generated_dir in unique_generated_dirs:
-        for custom_import in unique_imports_dirs:
-            generated_imports_dirs.append("{}/{}".format(generated_dir, custom_import))
+        for import_ in unique_imports_dirs:
+            generated_imports_dirs.append("{}/{}".format(generated_dir, import_))
 
     # types need to appear first in the mypy path since the module directories
     # are the same and mypy resolves the first ones, first.

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -18,7 +18,8 @@ MypyCacheInfo = provider(
     },
 )
 
-def _translate_custom_import(import_):
+def _extract_import_dir(import_):
+    # _main/path/to/package -> path/to/package
     return import_.split("/", 1)[-1]
 
 def _mypy_impl(target, ctx):
@@ -61,7 +62,7 @@ def _mypy_impl(target, ctx):
 
     if PyInfo in target:
         for import_ in target[PyInfo].imports.to_list():
-            imports_dirs[_translate_custom_import(import_)] = 1
+            imports_dirs[_extract_import_dir(import_)] = 1
 
     for dep in (ctx.rule.attr.deps + additional_types):
         depsets.append(dep.default_runfiles.files)
@@ -79,9 +80,8 @@ def _mypy_impl(target, ctx):
                    "typing_extensions" not in x
             ])
         elif PyInfo in dep and dep.label.workspace_name == "":
-            # _main/path/to/package -> path/to/package
             for import_ in dep[PyInfo].imports.to_list():
-                imports_dirs[_translate_custom_import(import_)] = 1
+                imports_dirs[_extract_import_dir(import_)] = 1
 
         if MypyCacheInfo in dep:
             upstream_caches.append(dep[MypyCacheInfo].directory)


### PR DESCRIPTION
imports in Bazel contain the transitive closure of all imports of all dependencies, which creates a significant number of duplicates and blows up MYPYPATH. This PR maintains a unique set of these imports instead.
