### PR TITLE
Split out version markers in requirements.txt

### DIFF
--- a/mypy/private/types.bzl
+++ b/mypy/private/types.bzl
@@ -46,6 +46,9 @@ def _generate_impl(rctx):
         if line.startswith("#") or line == "":
             continue
 
+        if ";" in line:
+            line, _ = line.split(";")
+
         if "~=" in line:
             req, _ = line.split("~=")
         elif "==" in line:


### PR DESCRIPTION
This is a valid line in a requirements.txt:

```
appnope==0.1.4 ; sys_platform == 'darwin' or platform_system == 'Darwin'
```

Previously this would fail because of multiple instances of `==`.
Dropping everything after the `;` should be safe, and doesn't cause
ambiguity for lines like:

```
requirement~=0.1.4 ; sys_platform == 'darwin'
```

Which could split on `~=` or `==`
