### PR TITLE
Explicitly load PyInfo provider

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -9,6 +9,7 @@ directories.
 
 load("@python_versions//3.12:defs.bzl", py312_binary = "py_binary")
 load("@rules_mypy_pip//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "PyInfo")
 load(":py_type_library.bzl", "PyTypeLibraryInfo")
 
 MypyCacheInfo = provider(


### PR DESCRIPTION
This fixes an issue with third-party rules such as:

 https://github.com/aspect-build/rules_py

where `PyInfo in target` is always false when `PyInfo` is not loaded.

Note that this does not require to depend on `rules_py`.