### PR TITLE
Do not type check _virtual_imports files

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -163,7 +163,7 @@ def _mypy_impl(target, ctx):
         result_info = [OutputGroupInfo(mypy = depset(outputs))]
 
     args.add_all([c.path for c in upstream_caches], before_each = "--upstream-cache")
-    args.add_all(ctx.rule.files.srcs)
+    args.add_all([s for s in ctx.rule.files.srcs if "/_virtual_imports/" not in s.short_path])
 
     if hasattr(ctx.attr, "_mypy_ini"):
         args.add("--mypy-ini", ctx.file._mypy_ini.path)


### PR DESCRIPTION
"virtual imports" are an implementation detail of `rules_python`

https://github.com/bazelbuild/rules_python/blob/main/python/private/proto/py_proto_library.bzl#L135

and the [well-known types](https://protobuf.dev/reference/protobuf/google.protobuf/) can be made available via the `protobuf` and `types-protobuf` wheels.

Removing the files in this directory from the type checking avoids spurious errors related to 3rd party code.