### PR TITLE
Improve `$MYPYPATH` behavior

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -78,7 +78,7 @@ def _opt_in(opt_in_tags, rule_tags):
 
     return False
 
-def yml_list(items):
+def _yml_list(items):
     return "\n".join(["- " + str(it) for it in items])
 
 def _mypy_impl(target, ctx):
@@ -154,16 +154,18 @@ def _mypy_impl(target, ctx):
         # and as a way to skip iterating over depset contents to find generated
         # file roots?
 
-    mypy_path = ":".join(sorted(types) + sorted(pyi_dirs) + sorted(imports_dirs))
-
     # types need to appear first in the mypy path since the module directories
     # are the same and mypy resolves the first ones, first.
-    print("---\nname: {}\ntypes:\n{}\npyi_dirs:\n{}\nimports_dirs:\n{}\n".format(
-        target.label,
-        yml_list(sorted(types)),
-        yml_list(sorted(pyi_dirs)),
-        yml_list(sorted(imports_dirs)),
-    ))
+
+    mypy_path = ":".join(sorted(types) + sorted(pyi_dirs) + sorted(imports_dirs))
+
+    if False: # FIXME: Debug condition
+        print("---\nname: {}\ntypes:\n{}\npyi_dirs:\n{}\nimports_dirs:\n{}\n".format(
+            target.label,
+            _yml_list(sorted(types)),
+            _yml_list(sorted(pyi_dirs)),
+            _yml_list(sorted(imports_dirs)),
+        ))
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -220,13 +220,14 @@ def _mypy_impl(target, ctx):
     return result_info
 
 def mypy(
-        mypy_cli = None,
-        mypy_ini = None,
-        types = None,
-        cache = True,
-        color = True,
-        suppression_tags = None,
-        opt_in_tags = None):
+    mypy_cli = None,
+    mypy_ini = None,
+    types = None,
+    cache = True,
+    color = True,
+    suppression_tags = None,
+    opt_in_tags = None,
+):
     """
     Create a mypy target inferring upstream caches from deps.
 
@@ -285,7 +286,13 @@ def mypy(
         } | additional_attrs,
     )
 
-def mypy_cli(name, deps = None, mypy_requirement = None, python_version = "3.12", tags = None):
+def mypy_cli(
+    name,
+    deps = None,
+    mypy_requirement = None,
+    python_version = "3.12",
+    tags = None,
+):
     """
     Produce a custom mypy executable for use with the mypy build rule.
 


### PR DESCRIPTION
It appears that `rules_mypy` has several issues interacting with MyPy, specifically regarding how Bazel wants to lay out runfiles. The relevant issue here is that MyPy is unaware of the `bazel-bin/` output tree, and so as with many other rulesets `rules_mypy` has to try and bridge that gap.

Today `rules_mypy` attempts to make generated output files (such as the `examples/demo/generated_file_imports` case) visible to MyPy by manipulating the `$MYPYPATH` environment variable so that the search path's merged view of the filesystem happens to lay out files in the appropriate logical structure to ignore the separation of some files into the `bazel-bin/` output tree while others remain in the source tree.

Unfortunately the present implementation of constructing the `$MYPYPATH` is fairly convoluted and produces path entries which may not accord with actual directory structures. This appears to be the root cause of issues such as theoremlp/rules_mypy#74.

This PR attempts to rework how the `$MYPYPATH` gets built to align it with the desired `$PYTHONPATH` behavior as defined by `imports=[]` directives on `PyInfo` providers of dependencies to produce more obviously correct and clearly defined behavior.

Under this changeset for any `import=[]` directive external import paths will be honored as-is (assuming that there are no generated external outputs, which is incomplete but presently true of `rules_python`), while internal import paths will be generated in duplicate; once as a source tree entry and once as a `bazel-bin/` entry.

This provides support for most cases of generated source files, appears to mitigate issues such as #74 which appear to be caused by generated files masking internal files or causing caches to be busted and simplifies the machinery somewhat.

### Alternatives
- Use [copy_to_bin](https://github.com/bazel-contrib/bazel-lib/blob/main/docs/copy_to_bin.md) to place all source files consistently into the bin tree, then just but the bin tree on the source path.
- Stop trying to put `bazel-bin/` tree onto the path at all and use `--shadow-file` to map entries in the source tree to their real locations in the `bazel-bin/` tree.
- Create a proper action sandbox directory with the expected files copied out of `bazel-bin` into their logical locations.

### Possible refinements
- Filter the `MYPYPATH` so that path entries are only added if there's a direct input source which is rooted on the entry
- Filter input sources so that only `.py` and `.pyi` sources are persisted as dependencies into the sandbox; discard data files and other generated output which can confuse the tree.

### Testing
- [X] Examples pass
- [X] https://github.com/aspect-build/bazel-examples/tree/main/py_mypy pass
- [X] #74 repro in private repo passes

### Open questions
- What motivated the `py_type_library` machinery & file relocation. Is that still required with this changeset? Does this changeset cause regressions there?