### PR TITLE
Avoid excessive BES event size

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -151,18 +151,15 @@ def _mypy_impl(target, ctx):
     args = ctx.actions.args()
     args.add("--output", output_file)
 
+    result_info = [OutputGroupInfo(mypy = depset([output_file]))]
     if ctx.attr.cache:
         cache_directory = ctx.actions.declare_directory(ctx.rule.attr.name + ".mypy_cache")
         args.add("--cache-dir", cache_directory.path)
 
         outputs = [output_file, cache_directory]
-        result_info = [
-            MypyCacheInfo(directory = cache_directory),
-            OutputGroupInfo(mypy = depset(outputs)),
-        ]
+        result_info.append([MypyCacheInfo(directory = cache_directory)])
     else:
         outputs = [output_file]
-        result_info = [OutputGroupInfo(mypy = depset(outputs))]
 
     args.add_all([c.path for c in upstream_caches], before_each = "--upstream-cache")
     args.add_all([s for s in ctx.rule.files.srcs if "/_virtual_imports/" not in s.short_path])

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -157,7 +157,7 @@ def _mypy_impl(target, ctx):
         args.add("--cache-dir", cache_directory.path)
 
         outputs = [output_file, cache_directory]
-        result_info.append([MypyCacheInfo(directory = cache_directory)])
+        result_info.append(MypyCacheInfo(directory = cache_directory))
     else:
         outputs = [output_file]
 


### PR DESCRIPTION
The files in requested output groups are announced as events on the Build Event Stream (BES), with declared directories expanded into the list of files they contain. Since mypy caches contain information about all transitive dependencies, including the cache directory in the `mypy` output group thus resulted in a very large number of (duplicated) files announced in build events when the aspect is applied to an entire repo, causing excessive upload times and BES sizes in the GBs.

This is fixed by dropping the cache directory from the `mypy` output group. It is still accessible via the `MypyCacheInfo` provider.