### PR TITLE
Put pyi dirs at the end of the mypy path

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -144,7 +144,7 @@ def _mypy_impl(target, ctx):
 
     # types need to appear first in the mypy path since the module directories
     # are the same and mypy resolves the first ones, first.
-    mypy_path = ":".join(sorted(types) + sorted(pyi_dirs) + sorted(external_deps) + sorted(imports_dirs) + sorted(generated_dirs) + sorted(generated_imports_dirs))
+    mypy_path = ":".join(sorted(types) + sorted(external_deps) + sorted(imports_dirs) + sorted(generated_dirs) + sorted(generated_imports_dirs) + sorted(pyi_dirs))
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 


### PR DESCRIPTION
The order of these matter if there are potential conflicts in the
MYPYPATH. Similar to generated_dirs I think it makes sense to keep the
generated file directories after the source file directories in case
there are conflicts.

This caused failures in our project since 411f64c0c952d12a46d011ce5537ca62d3d5ac3a
