### PR TITLE
Fix output bin_dir directory shadowing source directory

### DIFF
--- a/examples/demo/absolute_paths/bin/BUILD.bazel
+++ b/examples/demo/absolute_paths/bin/BUILD.bazel
@@ -5,6 +5,7 @@ py_binary(
     deps = [
         "//absolute_paths/lib:foo",
         "//absolute_paths/gen:bar",
+        "//absolute_paths/nested",
     ],
     visibility = ["//visibility:public"],
 )

--- a/examples/demo/absolute_paths/bin/BUILD.bazel
+++ b/examples/demo/absolute_paths/bin/BUILD.bazel
@@ -1,0 +1,10 @@
+py_binary(
+    name = "main",
+    srcs = ["main.py"],
+    main = "main.py",
+    deps = [
+        "//absolute_paths/lib:foo",
+        "//absolute_paths/gen:bar",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/demo/absolute_paths/bin/main.py
+++ b/examples/demo/absolute_paths/bin/main.py
@@ -1,0 +1,5 @@
+from absolute_paths.lib.foo import Foo
+from absolute_paths.gen.bar import BAR
+
+print(Foo)
+print(BAR)

--- a/examples/demo/absolute_paths/bin/main.py
+++ b/examples/demo/absolute_paths/bin/main.py
@@ -1,5 +1,7 @@
 from absolute_paths.lib.foo import Foo
 from absolute_paths.gen.bar import BAR
+from absolute_paths.nested import Nested
 
 print(Foo)
 print(BAR)
+print(Nested)

--- a/examples/demo/absolute_paths/gen/BUILD.bazel
+++ b/examples/demo/absolute_paths/gen/BUILD.bazel
@@ -1,0 +1,11 @@
+genrule(
+    name = "generate_source",
+    outs = ["bar.py"],
+    cmd = "echo 'BAR = 0' > $(OUTS)",
+)
+
+py_library(
+    name = "bar",
+    srcs = ["bar.py"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/demo/absolute_paths/lib/BUILD.bazel
+++ b/examples/demo/absolute_paths/lib/BUILD.bazel
@@ -1,0 +1,5 @@
+py_library(
+    name = "foo",
+    srcs = ["foo.py"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/demo/absolute_paths/lib/foo.py
+++ b/examples/demo/absolute_paths/lib/foo.py
@@ -1,0 +1,2 @@
+class Foo:
+    pass

--- a/examples/demo/absolute_paths/nested/BUILD.bazel
+++ b/examples/demo/absolute_paths/nested/BUILD.bazel
@@ -1,0 +1,5 @@
+py_library(
+    name = "nested",
+    srcs = ["__init__.py"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/demo/absolute_paths/nested/__init__.py
+++ b/examples/demo/absolute_paths/nested/__init__.py
@@ -1,0 +1,2 @@
+class Nested:
+    pass

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -142,9 +142,21 @@ def _mypy_impl(target, ctx):
         for import_ in imports_dirs.keys():
             generated_imports_dirs.append("{}/{}".format(generated_dir, import_))
 
-    # types need to appear first in the mypy path since the module directories
-    # are the same and mypy resolves the first ones, first.
-    mypy_path = ":".join(sorted(types) + sorted(external_deps) + sorted(imports_dirs) + sorted(generated_dirs) + sorted(generated_imports_dirs) + sorted(pyi_dirs))
+    mypy_path = ":".join(
+        # normally, mypy looks in the current directory last, but we explicitly want
+        # to check the current directory first, to avoid issues where mypy finds the
+        # output bin_dir from `generated_dirs` first
+        # https://github.com/theoremlp/rules_mypy/issues/88
+        ["."] +
+        # types need to appear first in the mypy path since the module directories
+        # are the same and mypy resolves the first ones, first.
+        sorted(types) +
+        sorted(external_deps) +
+        sorted(imports_dirs) +
+        sorted(generated_dirs) +
+        sorted(generated_imports_dirs) +
+        sorted(pyi_dirs)
+    )
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 


### PR DESCRIPTION
Fixes #88

In the test case added in this PR, the sandbox contains the following:
```
sandbox/.../execroot/_main/
|-- bazel-out/darwin_arm64-fastbuild/bin/
    |-- nested/
        |-- nested.mypy_cache/
|-- nested/
    |-- __init__.py
```
The `bazel-out/darwin_arm64-fastbuild/bin/` directory is added to MYPYPATH as part of `generated_dirs` and is necessary in certain situations, but here, mypy finds the `nested/` directory in `bazel-out/` instead of the one in the current directory, because mypy searches MYPYPATH before CWD.

In this PR, we explicitly add CWD first to ensure we look at source files before generated files