### PR TITLE
Provide an exclusion for requirement type mappings

### DIFF
--- a/mypy/private/types.bzl
+++ b/mypy/private/types.bzl
@@ -59,6 +59,9 @@ def _generate_impl(rctx):
             continue
 
         req = req.strip()
+        if req in rctx.attr.exclude_requirements:
+            continue
+
         if req.endswith("-stubs") or req.startswith("types-"):
             types.append(req)
 
@@ -70,5 +73,6 @@ generate = repository_rule(
     attrs = {
         "pip_requirements": attr.label(),
         "requirements_txt": attr.label(allow_single_file = True),
+        "exclude_requirements": attr.string_list(default = []),
     },
 )

--- a/mypy/types.bzl
+++ b/mypy/types.bzl
@@ -7,6 +7,7 @@ requirements = tag_class(
         "name": attr.string(),
         "pip_requirements": attr.label(),
         "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
+        "exclude_requirements": attr.string_list(default = [], mandatory = False),
     },
 )
 
@@ -17,6 +18,7 @@ def _extension(module_ctx):
                 name = tag.name,
                 pip_requirements = tag.pip_requirements,
                 requirements_txt = tag.requirements_txt,
+                exclude_requirements = tag.exclude_requirements,
             )
 
 types = module_extension(


### PR DESCRIPTION
Problem/Solution
============

There can be situations where `<name>-stub` or `types-<name>` get included where an associated `<name>` might not exist in the requirements. This can happen when custom modules of known public modules are prefixed differently then their associated `types-/-stub` package name. Adding an exclusion list helps ignore including packages that might not exist. 