### PR TITLE
Fix issue when importing generated stubs with absolute paths

### DIFF
--- a/examples/demo/absolute_gen_pyi/BUILD.bazel
+++ b/examples/demo/absolute_gen_pyi/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_python//python:py_library.bzl", "py_library")
+
+py_binary(
+    name = "main",
+    srcs = ["main.py"],
+    main = "main.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":stubs",
+    ],
+)
+
+genrule(
+    name = "generate_stubs",
+    outs = ["stubs.pyi"],
+    cmd = "echo 'STUB = 0' > $(OUTS)",
+)
+
+py_library(
+    name = "stubs",
+    imports = [".."],
+    pyi_srcs = [":generate_stubs"],
+)

--- a/examples/demo/absolute_gen_pyi/main.py
+++ b/examples/demo/absolute_gen_pyi/main.py
@@ -1,0 +1,1 @@
+from absolute_gen_pyi.stubs import STUB

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -20,8 +20,13 @@ MypyCacheInfo = provider(
 )
 
 def _extract_import_dir(import_):
-    # _main/path/to/package -> path/to/package
-    return import_.split("/", 1)[-1]
+    # Remove first parent from the directory
+    if "/" in import_:
+        # "_main/path/to/package" -> "path/to/package"
+        return import_.split("/", 1)[-1]
+    else:
+        # "_main" -> ""
+        return ""
 
 def _imports(target):
     if RulesPythonPyInfo in target:


### PR DESCRIPTION
The given test case fails when reverting the `mypy.bzl` change and passes with the change.