### PR TITLE
Set PYTHONNOUSERSITE=true for all mypy actions

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -187,7 +187,7 @@ def _mypy_impl(target, ctx):
     else:
         config_files = []
 
-    extra_env = {}
+    extra_env = {"PYTHONNOUSERSITE": "true"}
     if ctx.attr.color:
         # force color on
         extra_env["MYPY_FORCE_COLOR"] = "1"


### PR DESCRIPTION
Mypy can end up looking up the default search directories from the
python interpreter being used. This includes non-bazel system paths
which then pollute the environment.

https://github.com/python/mypy/blob/16e99de5376464beaa2cf086c1cd3dc5d26a791a/mypy/modulefinder.py#L836-L871
