### PR TITLE
Fix mypy linting non-python source files with custom rules

### DIFF
--- a/examples/demo/custom_rule/BUILD.bazel
+++ b/examples/demo/custom_rule/BUILD.bazel
@@ -1,0 +1,6 @@
+load(":foo.bzl", "foo")
+
+foo(
+    name = "foo",
+    srcs = ["foo.txt"],
+)

--- a/examples/demo/custom_rule/foo.bzl
+++ b/examples/demo/custom_rule/foo.bzl
@@ -1,0 +1,20 @@
+load("@rules_python//python:py_info.bzl", "PyInfo")
+
+def _impl(ctx):
+    return [
+        DefaultInfo(
+            files = depset(ctx.files.srcs),
+        ),
+        PyInfo(
+            transitive_sources = depset(ctx.files.srcs),
+        ),
+    ]
+
+foo = rule(
+    implementation = _impl,
+    attrs = {
+        "data": attr.label_list(allow_files = True),
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(),
+    },
+)

--- a/examples/demo/custom_rule/foo.txt
+++ b/examples/demo/custom_rule/foo.txt
@@ -1,0 +1,1 @@
+Invalid python syntax example

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -81,6 +81,15 @@ def _mypy_impl(target, ctx):
     if not hasattr(ctx.rule.files, "srcs"):
         return []
 
+    # Exclude non-python sources from custom rules that return PyInfo
+    lintable_srcs = [
+        s
+        for s in ctx.rule.files.srcs
+        if "/_virtual_imports/" not in s.short_path and s.extension in ("py", "pyi")
+    ]
+    if not lintable_srcs:
+        return []
+
     # we need to help mypy map the location of external deps by setting
     # MYPYPATH to include the site-packages directories.
     external_deps = {}
@@ -179,7 +188,7 @@ def _mypy_impl(target, ctx):
         outputs = [output_file]
 
     args.add_all([c.path for c in upstream_caches], before_each = "--upstream-cache")
-    args.add_all([s for s in ctx.rule.files.srcs if "/_virtual_imports/" not in s.short_path])
+    args.add_all(lintable_srcs)
 
     if hasattr(ctx.attr, "_mypy_ini"):
         args.add("--mypy-ini", ctx.file._mypy_ini.path)


### PR DESCRIPTION
If you write a custom rule that is designed to interop with python rules
you need to return PyInfo, in this case rules_mypy was attempting to
lint the source files of the target even if they were not python. This
is now scoped to only `.py` and `.pyi` files.

One example case for this is if you write a custom rule that creates a
python native extension and you want to be able to add it to the `deps`
of python rules.
