### PR TITLE
Add support for platform-specific requirements

### DIFF
--- a/mypy/private/types.bzl
+++ b/mypy/private/types.bzl
@@ -36,8 +36,17 @@ def _render_types_bzl(rctx, types):
     content += "}\n"
     return content
 
+def _get_requirements(rctx):
+    if rctx.attr.requirements_linux and "linux" in rctx.os.name:
+        return rctx.read(rctx.attr.requirements_linux)
+    if rctx.attr.requirements_windows and "windows" in rctx.os.name:
+        return rctx.read(rctx.attr.requirements_windows)
+    if rctx.attr.requirements_darwin and "mac os" in rctx.os.name:
+        return rctx.read(rctx.attr.requirements_darwin)
+    return rctx.read(rctx.attr.requirements_txt)
+
 def _generate_impl(rctx):
-    contents = rctx.read(rctx.attr.requirements_txt)
+    contents = _get_requirements(rctx)
 
     types = []
 
@@ -73,6 +82,9 @@ generate = repository_rule(
     attrs = {
         "pip_requirements": attr.label(),
         "requirements_txt": attr.label(allow_single_file = True),
+        "requirements_darwin": attr.label(allow_single_file = True),
+        "requirements_linux": attr.label(allow_single_file = True),
+        "requirements_windows": attr.label(allow_single_file = True),
         "exclude_requirements": attr.string_list(default = []),
     },
 )

--- a/mypy/types.bzl
+++ b/mypy/types.bzl
@@ -6,8 +6,20 @@ requirements = tag_class(
     attrs = {
         "name": attr.string(),
         "pip_requirements": attr.label(),
-        "requirements_txt": attr.label(mandatory = True, allow_single_file = True),
+        "requirements_txt": attr.label(allow_single_file = True),
         "exclude_requirements": attr.string_list(default = [], mandatory = False),
+        "requirements_darwin": attr.label(
+            allow_single_file = True,
+            doc = "MacOS only version of requirements_txt.",
+        ),
+        "requirements_linux": attr.label(
+            allow_single_file = True,
+            doc = "Linux only version of requirements_txt.",
+        ),
+        "requirements_windows": attr.label(
+            allow_single_file = True,
+            doc = "Windows only version of requirements_txt.",
+        ),
     },
 )
 
@@ -18,6 +30,9 @@ def _extension(module_ctx):
                 name = tag.name,
                 pip_requirements = tag.pip_requirements,
                 requirements_txt = tag.requirements_txt,
+                requirements_darwin = tag.requirements_darwin,
+                requirements_linux = tag.requirements_linux,
+                requirements_windows = tag.requirements_windows,
                 exclude_requirements = tag.exclude_requirements,
             )
 


### PR DESCRIPTION
The rules_python pip.parse module extension tag supports platform-specific requirements, e.g. [requirements_darwin](https://rules-python.readthedocs.io/en/latest/api/rules_python/python/extensions/pip.html#pip.parse.requirements_darwin). This PR adds analogous support to rules_mypy.

The use case for this are packages which have OS-specific pip dependencies. Pigweed (https://pigweed.dev) is one of these.