### PR TITLE
Align action mnemonics and progress messages with conventions

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -215,8 +215,8 @@ def _mypy_impl(target, ctx):
 
     py_type_files = [x for x in ctx.rule.files.data if x.basename == "py.typed" or x.extension == "pyi"]
     ctx.actions.run(
-        mnemonic = "mypy",
-        progress_message = "mypy %{label}",
+        mnemonic = "Mypy",
+        progress_message = "Checking Python types for %{label}",
         inputs = depset(
             direct = ctx.rule.files.srcs + py_type_files + pyi_files + upstream_caches + config_files,
             transitive = depsets,

--- a/mypy/private/py_type_library.bzl
+++ b/mypy/private/py_type_library.bzl
@@ -16,6 +16,7 @@ def _py_type_library_impl(ctx):
 
     ctx.actions.run(
         mnemonic = "BuildPyTypeLibrary",
+        progress_message = "Building Python type library %{output}",
         inputs = depset(transitive = [ctx.attr.typing.default_runfiles.files]),
         outputs = [directory],
         executable = ctx.executable._exec,


### PR DESCRIPTION
See the examples in https://bazel.build/rules/lib/builtins/actions#run:

- The mnemonic name is usually capitalized.
- The progress message is a complete phrase.