### PR TITLE
fix: rules_mypy work on Bazel 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       matrix:
         folder: [".", "examples/demo", "examples/opt-in"]
-        version: ["7.1.0", "8.0.0"]
+        version: ["7.x", "8x"]
         os: ["ubuntu-latest"]
         include:
           # Since examples are not fully compatible with bazel 9 yet
           # (due to usage of global py_* rules), only test root project for now
           # with this version.
           - folder: "."
-            version: "9.0.0rc3"
+            version: "9.x"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
         folder: [".", "examples/demo", "examples/opt-in"]
         version: ["7.1.0", "8.0.0"]
         os: ["ubuntu-latest"]
+        include:
+          # Since examples are not fully compatible with bazel 9 yet
+          # (due to usage of global py_* rules), only test root project for now
+          # with this version.
+          - folder: "."
+            version: "9.0.0rc3"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     version = "0.0.0",
 )
 
+bazel_dep(name = "bazel_features", version = "1.38.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "platforms", version = "0.0.8")

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -7,10 +7,20 @@ directories (the results of other mypy builds), the underlying action first atte
 directories.
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_mypy_pip//:requirements.bzl", "requirement")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_python//python:py_info.bzl", RulesPythonPyInfo = "PyInfo")
 load(":py_type_library.bzl", "PyTypeLibraryInfo")
+
+# Bazel >= 9 does not have any auto-loaded rules (like PyInfo).
+# This line detects if we are in older Bazel and need to support
+# built-in python provider.
+BuiltinPyInfo = bazel_features.globals.PyInfo
+
+def _has_builtin_py_info(target):
+    """Returns true iff the target has a builtin py_info provider."""
+    return BuiltinPyInfo != None and BuiltinPyInfo in target
 
 MypyCacheInfo = provider(
     doc = "Output details of the mypy build rule.",
@@ -31,8 +41,8 @@ def _extract_import_dir(import_):
 def _imports(target):
     if RulesPythonPyInfo in target:
         return target[RulesPythonPyInfo].imports.to_list()
-    elif PyInfo in target:
-        return target[PyInfo].imports.to_list()
+    elif _has_builtin_py_info(target):
+        return target[BuiltinPyInfo].imports.to_list()
     else:
         return []
 
@@ -69,7 +79,7 @@ def _mypy_impl(target, ctx):
     if target.label.workspace_root != "":
         return []
 
-    if RulesPythonPyInfo not in target and PyInfo not in target:
+    if not (RulesPythonPyInfo in target or _has_builtin_py_info(target)):
         return []
 
     # disable if a target is tagged with at least one suppression tag


### PR DESCRIPTION
**Summary**: Bazel 9 does not have any built in `PyInfo` anymore. So our references to it failed.  This PR fixes that.

**Changes**:
- Add a detection for if built-in PyInfo exists. Used canonical `bazel_features`.
- In mypy.bzl only handle built-in PyInfo if it exists.
- Add bazel 9 to CI.

**Related issues**:
- This should also fix https://github.com/bazel-contrib/rules_mypy/issues/102  
- Duplicate with https://github.com/bazel-contrib/rules_mypy/pull/118 in terms of functionality (I saw that PR after I wrote this). The code is more readable (no abuse of assigning RulesPythonPyInfo to legacy one + adds CI coverage).