### PR TITLE
feat: Add support for junit output

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -182,19 +182,26 @@ def _mypy_impl(target, ctx):
     mypy_path = ctx.configuration.host_path_separator.join([x for x in path_components if not _should_ignore_import(x)])
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
+    junit_xml = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_junit.xml")
 
     args = ctx.actions.args()
     args.add("--output", output_file)
+    args.add("--junit-xml", junit_xml)
 
-    result_info = [OutputGroupInfo(mypy = depset([output_file]))]
+    result_info = [
+        OutputGroupInfo(
+            mypy = depset([output_file]),
+            mypy_xml = depset([junit_xml]),
+        ),
+    ]
     if ctx.attr.cache:
         cache_directory = ctx.actions.declare_directory(ctx.rule.attr.name + ".mypy_cache")
         args.add("--cache-dir", cache_directory.path)
 
-        outputs = [output_file, cache_directory]
+        outputs = [output_file, junit_xml, cache_directory]
         result_info.append(MypyCacheInfo(directory = cache_directory))
     else:
-        outputs = [output_file]
+        outputs = [output_file, junit_xml]
 
     args.add_all([c.path for c in upstream_caches], before_each = "--upstream-cache")
     args.add_all(lintable_srcs)

--- a/mypy/private/mypy_runner.py
+++ b/mypy/private/mypy_runner.py
@@ -57,9 +57,10 @@ def managed_cache_dir(
 
 
 def run_mypy(
-    mypy_ini: Optional[str], cache_dir: str, srcs: list[str]
+    mypy_ini: Optional[str], junit_xml: Optional[str], cache_dir: str, srcs: list[str]
 ) -> tuple[str, str, int]:
     maybe_config = ["--config-file", mypy_ini] if mypy_ini else []
+    maybe_config += ["--junit-xml", junit_xml] if junit_xml else []
     report, errors, status = mypy.api.run(
         maybe_config
         + [
@@ -85,6 +86,7 @@ def run_mypy(
 
 def run(
     output: Optional[str],
+    junit_xml: Optional[str],
     cache_dir: Optional[str],
     upstream_caches: list[str],
     mypy_ini: Optional[str],
@@ -92,7 +94,7 @@ def run(
 ) -> None:
     if len(srcs) > 0:
         with managed_cache_dir(cache_dir, upstream_caches) as cache_dir:
-            report, errors, status = run_mypy(mypy_ini, cache_dir, srcs)
+            report, errors, status = run_mypy(mypy_ini, junit_xml, cache_dir, srcs)
     else:
         report, errors, status = "", "", 0
 
@@ -109,6 +111,7 @@ def run(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=False)
+    parser.add_argument("--junit-xml", required=False)
     parser.add_argument("-c", "--cache-dir", required=False)
     parser.add_argument("--upstream-cache", required=False, action="append")
     parser.add_argument("--mypy-ini", required=False)
@@ -116,12 +119,13 @@ def main() -> None:
     args = parser.parse_args()
 
     output: Optional[str] = args.output
+    junit_xml: Optional[str] = args.junit_xml
     cache_dir: Optional[str] = args.cache_dir
     upstream_cache: list[str] = args.upstream_cache or []
     mypy_ini: Optional[str] = args.mypy_ini
     srcs: list[str] = args.src
 
-    run(output, cache_dir, upstream_cache, mypy_ini, srcs)
+    run(output, junit_xml, cache_dir, upstream_cache, mypy_ini, srcs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch adds an extra output group, `mypy_xml` that generates the junit xml report.  This is useful to integrate in a CI.

Generate the file with
```
bazel build ---aspects //bazel/tools:aspects.bzl%mypy_aspect --output_groups=+mypy_xml ...
```