### PR TITLE
Skip generated sources in mypy aspect

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -87,11 +87,14 @@ def _mypy_impl(target, ctx):
     if not hasattr(ctx.rule.files, "srcs"):
         return []
 
-    # Exclude non-python sources from custom rules that return PyInfo
+    # Exclude non-python sources from custom rules that return PyInfo, and skip
+    # generated sources (e.g. py_console_script_binary entry-point shims and
+    # py_proto_library outputs) that users don't control and can't meaningfully
+    # type-check.
     lintable_srcs = [
         s
         for s in ctx.rule.files.srcs
-        if "/_virtual_imports/" not in s.short_path and s.extension in ("py", "pyi")
+        if "/_virtual_imports/" not in s.short_path and s.extension in ("py", "pyi") and s.is_source
     ]
     if not lintable_srcs:
         return []


### PR DESCRIPTION
## Summary

The mypy aspect currently runs on every `py_*` rule kind regardless of whether the target's srcs are hand-written or generated. This produces errors on code users don't own — notably:

- `py_console_script_binary` entry-point shims (rules_python generates `bazel-out/.../NAME_entry_point.py` containing a call like `sys.exit(console_entry())`), producing e.g. `"console_entry" does not return a value` or `Call to untyped function "main" in typed context`.
- `py_proto_library` outputs (see #125).

This PR filters `lintable_srcs` to source files only (`s.is_source`). Targets whose srcs are entirely generated produce an empty `lintable_srcs` and short-circuit via the existing early-return. Targets that mix hand-written and generated srcs still get the hand-written ones type-checked.

## Alternatives considered

- Tagging individual targets with `no-mypy`: works but users have to remember to add it to every `py_console_script_binary`, `py_proto_library`, etc. Not scalable.
- Filtering inside downstream repos' own aspect wrappers: not really possible — the aspect implementation is upstream-only.

## Test plan

- [x] Verified locally by patching in our monorepo: `py_console_script_binary` targets that previously failed mypy now build cleanly, and hand-written `py_library`/`py_binary` targets continue to be type-checked as before.

Draft until upstream maintainers weigh in on whether this is the preferred framing (vs. an opt-in flag or per-target tag). Happy to change direction.