### PR TITLE
Zip-based incremental mypy cache with optional compression

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -18,7 +18,7 @@ _LegacyPyInfo = bazel_features.globals.PyInfo or RulesPythonPyInfo
 MypyCacheInfo = provider(
     doc = "Output details of the mypy build rule.",
     fields = {
-        "zip_file": "Location of the mypy cache zip file produced by this target.",
+        "zip_files": "Depset of cache zip files (this target and transitive deps).",
     },
 )
 
@@ -107,7 +107,7 @@ def _mypy_impl(target, ctx):
     # generated dirs
     generated_dirs = {}
 
-    upstream_caches = []
+    upstream_cache_depsets = []
 
     types = []
 
@@ -147,7 +147,7 @@ def _mypy_impl(target, ctx):
                 imports_dirs[import_] = 1
 
         if MypyCacheInfo in dep:
-            upstream_caches.append(dep[MypyCacheInfo].zip_file)
+            upstream_cache_depsets.append(dep[MypyCacheInfo].zip_files)
 
         for file in dep.default_runfiles.files.to_list():
             root = file.root.path
@@ -186,8 +186,11 @@ def _mypy_impl(target, ctx):
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 
+    upstream_caches = depset(transitive = upstream_cache_depsets).to_list()
+
     args = ctx.actions.args()
     args.add("--output", output_file)
+    args.add("--zip-compress-level", ctx.attr._zip_compress_level)
 
     result_info = [OutputGroupInfo(mypy = depset([output_file]))]
     if ctx.attr.cache:
@@ -195,7 +198,10 @@ def _mypy_impl(target, ctx):
         args.add("--output-cache", output_cache.path)
 
         outputs = [output_file, output_cache]
-        result_info.append(MypyCacheInfo(zip_file = output_cache))
+        result_info.append(MypyCacheInfo(zip_files = depset(
+            direct = [output_cache],
+            transitive = upstream_cache_depsets,
+        )))
     else:
         outputs = [output_file]
 
@@ -238,6 +244,7 @@ def mypy(
         types = None,
         cache = True,
         color = True,
+        zip_compress_level = 1,
         suppression_tags = None,
         opt_in_tags = None):
     """
@@ -258,6 +265,8 @@ def mypy(
                     or requirements.txt file.
         cache:      (optional, default True) propagate the mypy cache
         color:      (optional, default True) use color in mypy output
+        zip_compress_level: (optional, default 1) deflate compression level for cache zips
+                    (0 = no compression, 9 = maximum compression)
         suppression_tags: (optional, default ["no-mypy"]) tags that suppress running
                     mypy on a particular target.
         opt_in_tags: (optional, default []) tags that must be present for mypy to run
@@ -295,6 +304,7 @@ def mypy(
             "_opt_in_tags": attr.string_list(default = opt_in_tags or []),
             "cache": attr.bool(default = cache),
             "color": attr.bool(default = color),
+            "_zip_compress_level": attr.int(default = zip_compress_level),
         } | additional_attrs,
     )
 

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -2,9 +2,9 @@
 mypy aspect.
 
 The mypy aspect runs mypy, succeeding if mypy is error free and failing if mypy produces errors. The
-result of the aspect is a mypy cache directory, located at [name].mypy_cache. When provided input cache
-directories (the results of other mypy builds), the underlying action first attempts to merge the cache
-directories.
+result of the aspect is a mypy cache zip file, located at [name].mypy_cache.zip. When provided input
+cache zip files (the results of other mypy builds), the underlying action first attempts to merge the
+caches.
 """
 
 load("@bazel_features//:features.bzl", "bazel_features")
@@ -18,7 +18,7 @@ _LegacyPyInfo = bazel_features.globals.PyInfo or RulesPythonPyInfo
 MypyCacheInfo = provider(
     doc = "Output details of the mypy build rule.",
     fields = {
-        "directory": "Location of the mypy cache produced by this target.",
+        "zip_file": "Location of the mypy cache zip file produced by this target.",
     },
 )
 
@@ -147,7 +147,7 @@ def _mypy_impl(target, ctx):
                 imports_dirs[import_] = 1
 
         if MypyCacheInfo in dep:
-            upstream_caches.append(dep[MypyCacheInfo].directory)
+            upstream_caches.append(dep[MypyCacheInfo].zip_file)
 
         for file in dep.default_runfiles.files.to_list():
             root = file.root.path
@@ -191,11 +191,11 @@ def _mypy_impl(target, ctx):
 
     result_info = [OutputGroupInfo(mypy = depset([output_file]))]
     if ctx.attr.cache:
-        cache_directory = ctx.actions.declare_directory(ctx.rule.attr.name + ".mypy_cache")
-        args.add("--cache-dir", cache_directory.path)
+        output_cache = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_cache.zip")
+        args.add("--output-cache", output_cache.path)
 
-        outputs = [output_file, cache_directory]
-        result_info.append(MypyCacheInfo(directory = cache_directory))
+        outputs = [output_file, output_cache]
+        result_info.append(MypyCacheInfo(zip_file = output_cache))
     else:
         outputs = [output_file]
 

--- a/mypy/private/mypy_runner.py
+++ b/mypy/private/mypy_runner.py
@@ -30,6 +30,8 @@ def _sorted_file_list(root: pathlib.Path) -> list[pathlib.PurePath]:
 def _deterministic_zip(
     src_dir: str,
     dst_zip: str,
+    exclude: set[pathlib.PurePath],
+    zip_compress_level: int,
 ) -> None:
     """
     Create a deterministic zip archive of src_dir at dst_zip.
@@ -46,6 +48,8 @@ def _deterministic_zip(
 
     with zipfile.ZipFile(dst_zip_path, mode="w") as zf:
         for relative_path in _sorted_file_list(src_path):
+            if relative_path in exclude:
+                continue
             full_path = src_path / relative_path
 
             info = zipfile.ZipInfo(filename=relative_path.as_posix())
@@ -54,36 +58,39 @@ def _deterministic_zip(
             zf.writestr(
                 info,
                 full_path.read_bytes(),
-                compress_type=zipfile.ZIP_STORED,
-                compresslevel=None,
+                compress_type=zipfile.ZIP_DEFLATED,
+                compresslevel=zip_compress_level,
             )
 
 
-def _merge_upstream_caches(cache_dir: str, upstream_caches: list[str]) -> None:
+def _merge_upstream_caches(cache_dir: str, upstream_caches: list[str]) -> set[pathlib.PurePath]:
     current = pathlib.Path(cache_dir)
-    current.mkdir(parents=True, exist_ok=True)
+    created_dirs: set[pathlib.Path] = {current}
+    unpacked_files: set[pathlib.PurePath] = set()
 
     for upstream_zip in upstream_caches:
-        # TODO(mark): maybe there's a more efficient way to synchronize the cache dirs?
         with zipfile.ZipFile(upstream_zip, "r") as zf:
             for info in zf.infolist():
                 relative_path = pathlib.PurePath(info.filename)
+                if relative_path.parts[0] == "missing_stubs" or relative_path in unpacked_files:
+                    continue
+
                 target_path = current / relative_path
-                target_path.parent.mkdir(parents=True, exist_ok=True)
+                parent_dir = target_path.parent
+                if parent_dir not in created_dirs:
+                    parent_dir.mkdir(parents=True, exist_ok=True)
+                    created_dirs.add(parent_dir)
 
-                if not target_path.exists():
-                    with zf.open(info, "r") as src, target_path.open("wb") as dst:
-                        shutil.copyfileobj(src, dst)
+                with zf.open(info, "r") as src, target_path.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                unpacked_files.add(relative_path)
 
-    # missing_stubs is mutable, so remove it
-    missing_stubs = current / "missing_stubs"
-    if missing_stubs.exists():
-        missing_stubs.unlink()
+    return unpacked_files
 
 
 @contextlib.contextmanager
 def managed_cache_dir(
-    output_cache: Optional[str], upstream_caches: list[str]
+    output_cache: Optional[str], upstream_caches: list[str], zip_compress_level: int,
 ) -> Iterator[str]:
     """
     Returns a managed cache directory.
@@ -92,10 +99,10 @@ def managed_cache_dir(
     When output_cache is not None, on context exit will create a single zip file there with contents of managed cache.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        _merge_upstream_caches(tmpdir, upstream_caches)
+        upstream_files = _merge_upstream_caches(tmpdir, upstream_caches)
         yield tmpdir
         if output_cache:
-            _deterministic_zip(tmpdir, output_cache)
+            _deterministic_zip(tmpdir, output_cache, upstream_files, zip_compress_level)
 
 
 def run_mypy(
@@ -130,10 +137,11 @@ def run(
     output_cache: Optional[str],
     upstream_caches: list[str],
     mypy_ini: Optional[str],
+    zip_compress_level: int,
     srcs: list[str],
 ) -> None:
     if srcs:
-        with managed_cache_dir(output_cache, upstream_caches) as cache_dir:
+        with managed_cache_dir(output_cache, upstream_caches, zip_compress_level) as cache_dir:
             report, errors, status = run_mypy(mypy_ini, cache_dir, srcs)
     else:
         report, errors, status = "", "", 0
@@ -154,6 +162,7 @@ def main() -> None:
     parser.add_argument("--output-cache", required=False)
     parser.add_argument("--upstream-cache", required=False, action="append")
     parser.add_argument("--mypy-ini", required=False)
+    parser.add_argument("--zip-compress-level", required=False, type=int, default=1)
     parser.add_argument("src", nargs="*")
     args = parser.parse_args()
 
@@ -161,9 +170,10 @@ def main() -> None:
     output_cache: Optional[str] = args.output_cache
     upstream_cache: list[str] = args.upstream_cache or []
     mypy_ini: Optional[str] = args.mypy_ini
+    zip_compress_level: int = args.zip_compress_level
     srcs: list[str] = args.src
 
-    run(output, output_cache, upstream_cache, mypy_ini, srcs)
+    run(output, output_cache, upstream_cache, mypy_ini, zip_compress_level, srcs)
 
 
 if __name__ == "__main__":

--- a/mypy/private/mypy_runner.py
+++ b/mypy/private/mypy_runner.py
@@ -1,34 +1,79 @@
 import argparse
 import contextlib
-import pathlib
 import os
+import pathlib
 import shutil
 import sys
 import tempfile
-from typing import Any, Generator, Optional
+import zipfile
+from typing import Iterator, Optional
 
 import mypy.api
 import mypy.util
+
+
+def _sorted_file_list(root: pathlib.Path) -> list[pathlib.PurePath]:
+    """
+    Return all files under root as relative paths, sorted deterministically by POSIX path.
+    """
+    root = root.resolve()
+    result: list[pathlib.PurePath] = []
+
+    for dirpath, _, filenames in os.walk(root):
+        relative_dirpath = pathlib.PurePath(dirpath).relative_to(root)
+        result.extend(relative_dirpath / name for name in filenames)
+
+    result.sort(key=lambda p: p.as_posix())
+    return result
+
+
+def _deterministic_zip(
+    src_dir: str,
+    dst_zip: str,
+) -> None:
+    """
+    Create a deterministic zip archive of src_dir at dst_zip.
+
+    Deterministic aspects:
+    - Only file entries (no explicit directory entries).
+    - Paths stored as relative POSIX paths.
+    - Entries sorted lexicographically by POSIX path.
+    - Implicit default: file timestamp set to the ZIP epoch (1980-01-01 00:00:00).
+    - Implicit default: file attributes set to 0o600 (?rw-------).
+    """
+    src_path = pathlib.Path(src_dir).resolve()
+    dst_zip_path = pathlib.Path(dst_zip).resolve()
+
+    with zipfile.ZipFile(dst_zip_path, mode="w") as zf:
+        for relative_path in _sorted_file_list(src_path):
+            full_path = src_path / relative_path
+
+            info = zipfile.ZipInfo(filename=relative_path.as_posix())
+            info.create_system = 3  # Unix
+
+            zf.writestr(
+                info,
+                full_path.read_bytes(),
+                compress_type=zipfile.ZIP_STORED,
+                compresslevel=None,
+            )
 
 
 def _merge_upstream_caches(cache_dir: str, upstream_caches: list[str]) -> None:
     current = pathlib.Path(cache_dir)
     current.mkdir(parents=True, exist_ok=True)
 
-    for upstream_dir in upstream_caches:
-        upstream = pathlib.Path(upstream_dir)
-
+    for upstream_zip in upstream_caches:
         # TODO(mark): maybe there's a more efficient way to synchronize the cache dirs?
-        for dirpath_str, _, filenames in os.walk(upstream.as_posix()):
-            dirpath = pathlib.Path(dirpath_str)
-            relative_dir = dirpath.relative_to(upstream)
-            for file in filenames:
-                upstream_path = dirpath / file
-                target_path = current / relative_dir / file
-                if not target_path.parent.exists():
-                    target_path.parent.mkdir(parents=True)
+        with zipfile.ZipFile(upstream_zip, "r") as zf:
+            for info in zf.infolist():
+                relative_path = pathlib.PurePath(info.filename)
+                target_path = current / relative_path
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+
                 if not target_path.exists():
-                    shutil.copy(upstream_path, target_path)
+                    with zf.open(info, "r") as src, target_path.open("wb") as dst:
+                        shutil.copyfileobj(src, dst)
 
     # missing_stubs is mutable, so remove it
     missing_stubs = current / "missing_stubs"
@@ -38,22 +83,19 @@ def _merge_upstream_caches(cache_dir: str, upstream_caches: list[str]) -> None:
 
 @contextlib.contextmanager
 def managed_cache_dir(
-    cache_dir: Optional[str], upstream_caches: list[str]
-) -> Generator[str, Any, Any]:
+    output_cache: Optional[str], upstream_caches: list[str]
+) -> Iterator[str]:
     """
     Returns a managed cache directory.
 
-    When cache_dir exists, returns a merged view of cache_dir with upstream_caches.
-    Otherwise, returns a temporary directory that will be cleaned up when the resource
-    is released.
+    Returns a temporary directory with a merged view of upstream_caches.
+    When output_cache is not None, on context exit will create a single zip file there with contents of managed cache.
     """
-    if cache_dir:
-        _merge_upstream_caches(cache_dir, list(upstream_caches))
-        yield cache_dir
-    else:
-        tmpdir = tempfile.TemporaryDirectory()
-        yield tmpdir.name
-        tmpdir.cleanup()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _merge_upstream_caches(tmpdir, upstream_caches)
+        yield tmpdir
+        if output_cache:
+            _deterministic_zip(tmpdir, output_cache)
 
 
 def run_mypy(
@@ -85,19 +127,19 @@ def run_mypy(
 
 def run(
     output: Optional[str],
-    cache_dir: Optional[str],
+    output_cache: Optional[str],
     upstream_caches: list[str],
     mypy_ini: Optional[str],
     srcs: list[str],
 ) -> None:
-    if len(srcs) > 0:
-        with managed_cache_dir(cache_dir, upstream_caches) as cache_dir:
+    if srcs:
+        with managed_cache_dir(output_cache, upstream_caches) as cache_dir:
             report, errors, status = run_mypy(mypy_ini, cache_dir, srcs)
     else:
         report, errors, status = "", "", 0
 
     if output:
-        with open(output, "w+") as file:
+        with open(output, "w") as file:
             file.write(errors)
             file.write(report)
 
@@ -109,19 +151,19 @@ def run(
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=False)
-    parser.add_argument("-c", "--cache-dir", required=False)
+    parser.add_argument("--output-cache", required=False)
     parser.add_argument("--upstream-cache", required=False, action="append")
     parser.add_argument("--mypy-ini", required=False)
     parser.add_argument("src", nargs="*")
     args = parser.parse_args()
 
     output: Optional[str] = args.output
-    cache_dir: Optional[str] = args.cache_dir
+    output_cache: Optional[str] = args.output_cache
     upstream_cache: list[str] = args.upstream_cache or []
     mypy_ini: Optional[str] = args.mypy_ini
     srcs: list[str] = args.src
 
-    run(output, cache_dir, upstream_cache, mypy_ini, srcs)
+    run(output, output_cache, upstream_cache, mypy_ini, srcs)
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,6 @@ Compared to [bazel-mypy-integration](https://github.com/bazel-contrib/bazel-mypy
 - Propagation of the mypy cache between dependencies within a repository to avoid exponential type-checking work
 - Robust (and automated) support for including 3rd party types/stubs packages
 
-> [!WARNING]  
-> rules_mypy's build actions produce mypy caches as outputs, and these may contain large file counts and that will only grow as a dependency chain grows. This may have an impact on the size and usage of build and/or remote caches.
-
 ## Usage
 
 This aspect will run over any `py_binary`, `py_library` or `py_test`.
@@ -150,6 +147,19 @@ load("@rules_mypy//mypy:mypy.bzl", "mypy")
 
 mypy_aspect = mypy(
     opt_in_tags = ["typecheck"],
+    types = types,
+)
+```
+
+## Cache compression
+
+Compression level for the cache zip files can be configured with the `zip_compress_level` parameter (0 = no compression, 9 = maximum compression, default 1):
+
+```starlark
+load("@rules_mypy//mypy:mypy.bzl", "mypy")
+
+mypy_aspect = mypy(
+    zip_compress_level = 0,
     types = types,
 )
 ```


### PR DESCRIPTION
Previously, the output of `mypy_runner.py` was declared as a tree artifact (`declare_directory`). This PR changes it to a single zip file (`declare_file`) instead, which works better with bazel remote cache.

Each target's output zip now contains only the mypy cache entries produced by that target. Upstream caches are propagated via a depset and passed individually to the runner, which merges them by unpacking each zip in order and skipping already-seen entries. After the mypy run, only the new entries are written to the output zip.

Zip was chosen over other archive formats (for example, `tar.gz`) because it supports random access, allowing individual entries to be skipped or extracted without reading the entire archive. Output zips use deflate compression level 1 by default, configurable via the `zip_compress_level` parameter on the `mypy()` aspect (0 = no compression, 9 = maximum).

Results on a private repository compared to the original tree artifact approach (with `zip_compress_level=1`):
- ~50x reduction in total build artifact size
- ~10% speedup of local runs