### PR TITLE
fix: Limit inputs to action

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -130,7 +130,11 @@ def _mypy_impl(target, ctx):
         if RulesPythonPyInfo in dep and hasattr(dep[RulesPythonPyInfo], "direct_pyi_files"):
             pyi_files.extend(dep[RulesPythonPyInfo].direct_pyi_files.to_list())
             pyi_dirs |= {"%s/%s" % (ctx.bin_dir.path, imp): None for imp in _extract_imports(dep) if imp != "site-packages" and imp != "_main"}
-        depsets.append(dep.default_runfiles.files)
+
+        if RulesPythonPyInfo in dep:
+            depsets.append(dep[RulesPythonPyInfo].transitive_sources)
+            depsets.append(dep[RulesPythonPyInfo].transitive_pyi_files)
+
         if PyTypeLibraryInfo in dep:
             types.append(dep[PyTypeLibraryInfo].directory.path + "/site-packages")
         elif dep.label in type_mapping:


### PR DESCRIPTION
In our codebase, we have a long chain of C++ compilation that ends up getting fed to our Python targets and, by extension, these mypy actions. Since mypy doesn't actually import anything, these compiled artifacts are unnecessary.

This uses a different method to grab the things that mypy _will_ look at, those being transitive .py and .pyi files.